### PR TITLE
Fix global rate limiting

### DIFF
--- a/Working_examples/Killercoda/deployments-mc/envoy-deployment.yaml
+++ b/Working_examples/Killercoda/deployments-mc/envoy-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: envoy
-        image: envoyproxy/envoy:v1.31.2
+        image: envoyproxy/envoy:v1.33-latest
         args: ["-c", "/etc/envoy/envoy.yaml", "--log-level", "info"]
         ports:
         - containerPort: 10000

--- a/Working_examples/Killercoda/deployments-mc/rlser-deployment.yaml
+++ b/Working_examples/Killercoda/deployments-mc/rlser-deployment.yaml
@@ -18,7 +18,8 @@ spec:
         ports:
         - containerPort: 8080 # HTTP debug/admin
         - containerPort: 8081 # gRPC RLS port
-        command: ["ratelimit", "-c", "/data/ratelimit/config/config.yaml", "--log-level", "debug"]
+        #command: ["ratelimit", "-c", "/data/ratelimit/config/config.yaml", "--log-level", "debug"]
+        command: ["ratelimit", "--log-level", "debug"]
         env:
         - name: USE_STATSD
           value: "false"
@@ -34,7 +35,8 @@ spec:
           value: ratelimit
         volumeMounts:
         - name: ratelimit-config
-          mountPath: /data/ratelimit/config
+          mountPath: '/data/ratelimit/config/config.yaml'
+          subPath: config.yaml
       volumes:
       - name: ratelimit-config
         configMap:

--- a/Working_examples/Killercoda/deployments-mc/services.yaml
+++ b/Working_examples/Killercoda/deployments-mc/services.yaml
@@ -35,3 +35,15 @@ spec:
   - port: 10000
     targetPort: 10000
     nodePort: 30081
+---
+# ratelimit service
+apiVersion: v1
+kind: Service
+metadata:
+  name: ratelimit
+spec:
+  selector:
+    app: ratelimit
+  ports:
+  - port: 8081
+    targetPort: 8081


### PR DESCRIPTION
This patch fixes three problems:

1) Add the missing manifest for the ratelimit service.

2) Mount only the config file, not the config direcory. Mounting the
   directory causes the service to load the config file mutliple times
   becuase of the way k8s uses symlinks in mounts. This fails with a
   "duplicate domain" error. The service comes up, but responds with
   errors to all requests.

3) Bump the envoy version to 1.33. Global rate limiting doesn't seem to
   work at all before that, at least not using
   type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit.

Now It Works On My Machine (tm)